### PR TITLE
 DEV-1987-woocommerce-deferbutton installments for vicomm from app

### DIFF
--- a/assets/js/payment_checkout.js
+++ b/assets/js/payment_checkout.js
@@ -7,7 +7,7 @@ jQuery(document).ready(function($) {
     var webhook_p = checkout_values.getAttribute('webhook_p');
     var staging = checkout_values.getAttribute('environment');
     var environment = (staging === "yes") ? "stg" : "prod";
-    var enable_installments = checkout_values.getAttribute('enable_installments');
+    // var enable_installments = checkout_values.getAttribute('enable_installments');
 
     var paymentCheckout = new PaymentCheckout.modal({
         client_app_code: app_code_js,
@@ -62,7 +62,7 @@ jQuery(document).ready(function($) {
             order_amount: Number(order_data.purchase_amount),
             order_vat: Number(order_data.vat),
             order_reference: order_data.purchase_order_id.toString(),
-            order_installments_type: enable_installments === "no" ? -1 : 0,
+            order_installments_type: Number(btnOpenCheckout.getAttribute('installments_type_commerce')),
             billing_address: order_data.billing_address
         });
     });
@@ -82,9 +82,9 @@ jQuery(document).ready(function($) {
         if (document.getElementById("msj-failed")) {
             $("#msj-failed").addClass("hide");
         }
-        if (document.getElementById("installments_div")) {
-            $("#installments_div").addClass("hide");
-        }
+        // if (document.getElementById("installments_div")) {
+        //     $("#installments_div").addClass("hide");
+        // }
     }
 
     function showMessageError() {

--- a/includes/pg-woocommerce-helper.php
+++ b/includes/pg-woocommerce-helper.php
@@ -234,50 +234,29 @@ class PG_WC_Helper
      * @param string $enable_installments
      * @return void
      */
-    public static function get_installments_type($enable_installments)
+    public static function get_installments_type($enable_installments, $environment, $card_button_text)
     {
-        $installments_options = [
-            0  => __('Enable Installments', 'pg_woocommerce'),
-            1  => __('Revolving and deferred without interest (The bank will pay to the commerce the installment, month by month)(Ecuador)', 'pg_woocommerce'),
-            2  => __('Deferred with interest (Ecuador, México)', 'pg_woocommerce'),
-            3  => __('Deferred without interest (Ecuador, México)', 'pg_woocommerce'),
-            7  => __('Deferred with interest and months of grace (Ecuador)', 'pg_woocommerce'),
-            6  => __('Deferred without interest pay month by month (Ecuador)(Medianet)', 'pg_woocommerce'),
-            9  => __('Deferred without interest and months of grace (Ecuador, México)', 'pg_woocommerce'),
-            10 => __('Deferred without interest promotion bimonthly (Ecuador)(Medianet)', 'pg_woocommerce'),
-            21 => __('For Diners Club exclusive, deferred with and without interest (Ecuador)', 'pg_woocommerce'),
-            22 => __('For Diners Club exclusive, deferred with and without interest (Ecuador)', 'pg_woocommerce'),
-            30 => __('Deferred with interest pay month by month (Ecuador)(Medianet)', 'pg_woocommerce'),
-            50 => __('Deferred without interest promotions (Supermaxi)(Ecuador)(Medianet)', 'pg_woocommerce'),
-            51 => __('Deferred with interest (Cuota fácil)(Ecuador)(Medianet)', 'pg_woocommerce'),
-            52 => __('Without interest (Rendecion Produmillas)(Ecuador)(Medianet)', 'pg_woocommerce'),
-            53 => __('Without interest sale with promotions (Ecuador)(Medianet)', 'pg_woocommerce'),
-            70 => __('Deferred special without interest (Ecuador)(Medianet)', 'pg_woocommerce'),
-            72 => __('Credit without interest (cte smax)(Ecuador)(Medianet)', 'pg_woocommerce'),
-            73 => __('Special credit without interest (smax)(Ecuador)(Medianet)', 'pg_woocommerce'),
-            74 => __('Prepay without interest (smax)(Ecuador)(Medianet)', 'pg_woocommerce'),
-            75 => __('Defered credit without interest (smax)(Ecuador)(Medianet)', 'pg_woocommerce'),
-            90 => __('Without interest with months of grace (Supermaxi)(Ecuador)(Medianet)', 'pg_woocommerce'),
-        ];
+        // to uncomment
+        $auth_token = PG_WC_Helper::generate_auth_token('client');
+        $commerce_data = PG_WC_Utils::get_enable_installments_app($environment, $auth_token);
+        $installments_options_app = $commerce_data['installments_options'];
+        $enable_installments_app = filter_var($commerce_data['enable_installments'], FILTER_VALIDATE_BOOLEAN)
         ?>
-        <div class="select" id="installments_div">
-            <select name="installments_type" id="installments_type">
-                <option selected disabled><?php _e('Installments Type', 'pg_woocommerce'); ?>:</option>
-                <option value=-1><?php _e('Without Installments', 'pg_woocommerce'); ?></option>
-                <?php
-                if ($enable_installments == 'yes')
-                {
-                    foreach($installments_options as $value => $text)
-                    {
-                        ?>
-                        <option value=<?php echo $value;?>><?php echo $text; ?></option>
-                        <?php
-                    }
-                }
-                ?>
-            </select>
-            <br><br>
-        </div>
+        <?php
+        if ($enable_installments_app and in_array('3', array_keys($commerce_data['installments_options']))){
+            $enable_installments ='yes';
+            $installments_options = 3;
+            $card_button_text = __('Deferred without interest', 'gp_woocommerce');
+        }else{
+            $enable_installments = 'no';
+            $installments_options = -1;
+        }
+        ?>
+        <button id="checkout-button" 
+            class="js-payment-checkout" 
+            installments_type_commerce=<?php echo $installments_options; ?>>
+            <?php echo $card_button_text; ?>
+        </button>
         <?php
     }
 }

--- a/includes/pg-woocommerce-utils.php
+++ b/includes/pg-woocommerce-utils.php
@@ -1,4 +1,5 @@
 <?php
+require_once( dirname( __DIR__ ) . '/pg-woocommerce-plugin.php' );
 class PG_WC_Utils
 {
     /**
@@ -264,5 +265,27 @@ class PG_WC_Utils
         );
 
         return isset($countries[$country]) ? $countries[$country] : $country;
+    }
+
+    public static function get_enable_installments_app($environment, $auth_token){
+        $url_commerce = ($environment == 'yes') ? 'https://ccapi-stg.'.PG_DOMAIN.PG_COMMERCE : 'https://ccapi.'.PG_DOMAIN.PG_COMMERCE;
+        $ch = curl_init($url_commerce);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "GET");
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:application/json', 'Auth-Token:' . $auth_token));
+
+        try {
+            $response = curl_exec($ch);
+        } catch (Exception $e) {
+            curl_close($ch);
+            return  array('enable_installments' => $e) ;
+        }
+        $get_response = json_decode($response, true);
+        $enable_installments = $get_response['enable_installments'];
+        $installments_options = $get_response['installments_options'];
+        return array(
+            'enable_installments' => $enable_installments,
+            'installments_options' => $installments_options 
+        );
     }
 }

--- a/pg-woocommerce-plugin.php
+++ b/pg-woocommerce-plugin.php
@@ -24,6 +24,7 @@ const PG_FLAVOR = "Paymentez";
 const PG_DOMAIN = "paymentez.com";
 const PG_REFUND = "/v2/transaction/refund/";
 const PG_LTP = "/linktopay/init_order/";
+const PG_COMMERCE = "/utils/commerce/";
 
 add_action( 'plugins_loaded', 'pg_woocommerce_plugin' );
 
@@ -185,7 +186,9 @@ if (!function_exists('pg_woocommerce_plugin')) {
                     <script src="https://cdn.paymentez.com/ccapi/sdk/payment_checkout_stable.min.js"></script>
                 </div>
 
-                <button id="checkout-button" class="js-payment-checkout"><?php echo $this->card_button_text; ?></button>
+                <?php
+                    PG_WC_Helper::get_installments_type($this->enable_installments, $this->environment, $this->card_button_text);
+                ?>
 
                 <div id="order_data" class="hide">
                     <?php echo json_encode($order_data); ?>


### PR DESCRIPTION
**Descripción**
Se coloco la opción según el valor que tenga el comercio si es pago en MSI o pago normal
solo muestra un botón según la opción, se hicieron cambios en
pg-woocommerce-utils: se agrego el método get_enable_installments_app
gp.woocommerce-helper: se cambio el método get_installments_type
**Debe subirse junto a estos cambios** https://github.com/paymentez/paymentez_ccapi/pull/2053